### PR TITLE
Update existing/failing link to current location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## DEPRECATED.  Use:  https://github.com/elastic/cloud-on-k8s/blob/master/hack/diagnostics/eck-dump.sh
+## DEPRECATED.  Use:  https://github.com/elastic/cloud-on-k8s/blob/master/support/diagnostics/eck-dump.sh
 
 
 ## ECK Diagnostics


### PR DESCRIPTION
Clicking the existing link leads to a 404. Updating to the current file location.